### PR TITLE
Fix subscription leak on renewal failure (v1.2.24)

### DIFF
--- a/lib/lib.external.upnp-device-client.js
+++ b/lib/lib.external.upnp-device-client.js
@@ -51,7 +51,7 @@ function DeviceClient(url) {
   this.subscriptions = {};
   this.userAgent = "";
   this._subscriptionCreatedAt = {}; // Track when subscriptions were created
-  this.activeSockets = []; // FIX Phase 2b: Track active sockets for cleanup
+  this.activeSockets = []; // Track active sockets for cleanup
 }
 
 util.inherits(DeviceClient, EventEmitter);
@@ -636,7 +636,7 @@ DeviceClient.prototype.ensureEventingServer = function(callback) {
     var iface = this.getIfaceForUrl(this.url);
     this.server.listen(0, ip.address(iface));
     
-    // FIX Phase 2b: Track active sockets to force cleanup on release
+    // Track active sockets to force cleanup on release
     // Node.js server.close() does not close idle Keep-Alive connections, 
     // leading to socket leaks on the host. We must track and destroy them manually.
     this.server.on('connection', function(socket) {
@@ -684,7 +684,7 @@ DeviceClient.prototype.releaseEventingServer = function(_force = false) {
         activeSockets: this.activeSockets.length
       });
       
-      // FIX Phase 2b: Force destroy all active sockets
+      // Force destroy all active sockets
       // This is required because server.close() only stops accepting NEW connections
       // but keeps existing Keep-Alive connections open indefinitely.
       if (this.activeSockets) {
@@ -953,5 +953,6 @@ function resolveService(serviceId) {
 // Export additional utilities for monitoring
 DeviceClient.setSubscriptionLogger = setSubscriptionLogger;
 DeviceClient.getSubscriptionMetrics = getSubscriptionMetrics;
+
 
 module.exports = DeviceClient;

--- a/lib/lib.external.upnp-device-client.js
+++ b/lib/lib.external.upnp-device-client.js
@@ -13,6 +13,27 @@ var PACKAGE_VERSION = "";
 
 var SUBSCRIPTION_TIMEOUT = 300;
 
+// Global subscription tracking for monitoring connection leaks
+var globalSubscriptionCount = 0;
+var globalServerCount = 0;
+
+// Logging function that can be overridden for integration with external loggers
+var subscriptionLogger = function(level, message, context) {
+  var timestamp = new Date().toISOString();
+  var contextStr = context ? ' ' + JSON.stringify(context) : '';
+  console.log('[' + timestamp + '] [UPnP-Client] [' + level + '] ' + message + contextStr);
+};
+
+function setSubscriptionLogger(logger) {
+  subscriptionLogger = logger;
+}
+
+function getSubscriptionMetrics() {
+  return {
+    globalSubscriptionCount: globalSubscriptionCount,
+    globalServerCount: globalServerCount
+  };
+}
 
 function DeviceClient(url) {
   EventEmitter.call(this);
@@ -24,6 +45,7 @@ function DeviceClient(url) {
   this.listening = false;
   this.subscriptions = {};
   this.userAgent = "";
+  this._subscriptionCreatedAt = {}; // Track when subscriptions were created
 }
 
 util.inherits(DeviceClient, EventEmitter);
@@ -172,11 +194,17 @@ DeviceClient.prototype.callAction = function(serviceId, actionName, params, call
 DeviceClient.prototype.subscribe = function(serviceId, listener) {
   var self = this;
   serviceId = resolveService(serviceId);
+  var deviceName = this.deviceDescription ? this.deviceDescription.friendlyName : this.url;
 
   if(this.subscriptions[serviceId]) {
     // If we already have a subscription to this service,
     // add the provided callback to the listeners and return
     this.subscriptions[serviceId].listeners.push(listener);
+    subscriptionLogger('DEBUG', 'Added listener to existing subscription', {
+      device: deviceName,
+      service: serviceId,
+      listenerCount: this.subscriptions[serviceId].listeners.length
+    });
     return;
   }
 
@@ -212,6 +240,13 @@ DeviceClient.prototype.subscribe = function(serviceId, listener) {
         if(res.statusCode !== 200) {
           var err = new Error('SUBSCRIBE error');
           err.statusCode = res.statusCode;
+          subscriptionLogger('ERROR', 'SUBSCRIBE failed', {
+            device: deviceName,
+            service: serviceId,
+            statusCode: res.statusCode,
+            globalSubscriptions: globalSubscriptionCount,
+            globalServers: globalServerCount
+          });
           self.releaseEventingServer();
           self.emit('error', err);
           return;
@@ -219,9 +254,27 @@ DeviceClient.prototype.subscribe = function(serviceId, listener) {
 
         var sid = res.headers['sid'];
         var timeout = parseTimeout(res.headers['timeout']);
+        
+        globalSubscriptionCount++;
+        self._subscriptionCreatedAt[serviceId] = Date.now();
+        
+        subscriptionLogger('INFO', 'SUBSCRIBE success', {
+          device: deviceName,
+          service: serviceId,
+          sid: sid,
+          timeout: timeout,
+          globalSubscriptions: globalSubscriptionCount,
+          globalServers: globalServerCount
+        });
 
         function renew() {
-          debug('renew subscription to %s', serviceId);
+          var renewStartTime = Date.now();
+          subscriptionLogger('DEBUG', 'Renewing subscription', {
+            device: deviceName,
+            service: serviceId,
+            sid: sid,
+            ageMs: renewStartTime - self._subscriptionCreatedAt[serviceId]
+          });
 
           var options = parseUrl(service.eventSubURL);
           options.method = 'SUBSCRIBE';
@@ -235,6 +288,15 @@ DeviceClient.prototype.subscribe = function(serviceId, listener) {
             if(res.statusCode !== 200) {
               var err = new Error('SUBSCRIBE renewal error');
               err.statusCode = res.statusCode;
+              subscriptionLogger('ERROR', 'SUBSCRIBE renewal failed - POTENTIAL LEAK', {
+                device: deviceName,
+                service: serviceId,
+                sid: sid,
+                statusCode: res.statusCode,
+                globalSubscriptions: globalSubscriptionCount,
+                globalServers: globalServerCount,
+                note: 'Old subscription may remain on host'
+              });
               // XXX: should we clear the subscription and release the server here ?
               self.emit('error', err);
               return;
@@ -243,12 +305,27 @@ DeviceClient.prototype.subscribe = function(serviceId, listener) {
             var timeout = parseTimeout(res.headers['timeout']);
 
             var renewTimeout = Math.max(timeout - 30, 30); // renew 30 seconds before expiration
-            debug('renewing subscription to %s in %d seconds', serviceId, renewTimeout);
+            subscriptionLogger('DEBUG', 'SUBSCRIBE renewal success', {
+              device: deviceName,
+              service: serviceId,
+              sid: sid,
+              newTimeout: timeout,
+              nextRenewalIn: renewTimeout
+            });
             var timer = setTimeout(renew, renewTimeout * 1000);
             self.subscriptions[serviceId].timer = timer;
           });
 
           req.on('error', function(err) {
+            subscriptionLogger('ERROR', 'SUBSCRIBE renewal request error - POTENTIAL LEAK', {
+              device: deviceName,
+              service: serviceId,
+              sid: sid,
+              error: err.message,
+              globalSubscriptions: globalSubscriptionCount,
+              globalServers: globalServerCount,
+              note: 'Old subscription may remain on host'
+            });
             self.emit('error', err);
           });
 
@@ -297,7 +374,14 @@ DeviceClient.prototype.unsubscribe = function(serviceId, listener) {
 
   if(subscription.listeners.length === 0) {
     // If there's no listener left for this service, unsubscribe from it
-    debug('unsubscribe from service %s', serviceId);
+    var deviceName = this.deviceDescription ? this.deviceDescription.friendlyName : this.url;
+    subscriptionLogger('INFO', 'UNSUBSCRIBE starting', {
+      device: deviceName,
+      service: serviceId,
+      sid: subscription.sid,
+      globalSubscriptions: globalSubscriptionCount,
+      globalServers: globalServerCount
+    });
 
     var options = parseUrl(subscription.url);
 
@@ -311,8 +395,23 @@ DeviceClient.prototype.unsubscribe = function(serviceId, listener) {
       if(res.statusCode !== 200) {
         var err = new Error('UNSUBSCRIBE error');
         err.statusCode = res.statusCode;
+        subscriptionLogger('ERROR', 'UNSUBSCRIBE failed - subscription may remain on host', {
+          device: deviceName,
+          service: serviceId,
+          sid: subscription.sid,
+          statusCode: res.statusCode
+        });
         return self.emit('error', err);
       }
+
+      globalSubscriptionCount = Math.max(0, globalSubscriptionCount - 1);
+      delete self._subscriptionCreatedAt[serviceId];
+      subscriptionLogger('INFO', 'UNSUBSCRIBE success', {
+        device: deviceName,
+        service: serviceId,
+        globalSubscriptions: globalSubscriptionCount,
+        globalServers: globalServerCount
+      });
 
       clearTimeout(self.subscriptions[serviceId].timer);
       delete self.subscriptions[serviceId];
@@ -322,8 +421,18 @@ DeviceClient.prototype.unsubscribe = function(serviceId, listener) {
     });
 
     req.on('error', function(err) {
+      subscriptionLogger('WARN', 'UNSUBSCRIBE request error - cleaning up locally but subscription may remain on host', {
+        device: deviceName,
+        service: serviceId,
+        sid: subscription.sid,
+        error: err.message,
+        globalSubscriptions: globalSubscriptionCount,
+        globalServers: globalServerCount
+      });
       self.emit('error', err);
       // well this may occur if the client was removed and can not answer anymore, so we have to remove the subscription!
+      globalSubscriptionCount = Math.max(0, globalSubscriptionCount - 1);
+      delete self._subscriptionCreatedAt[serviceId];
       clearTimeout(self.subscriptions[serviceId].timer);
       delete self.subscriptions[serviceId];
       self.releaseEventingServer();
@@ -347,7 +456,14 @@ DeviceClient.prototype.unsubscribeAll = function(serviceId) {
 
   if(subscription.listeners.length === 0) {
     // If there's no listener left for this service, unsubscribe from it
-    debug('unsubscribe from service %s', serviceId);
+    var deviceName = this.deviceDescription ? this.deviceDescription.friendlyName : this.url;
+    subscriptionLogger('INFO', 'UNSUBSCRIBE_ALL starting', {
+      device: deviceName,
+      service: serviceId,
+      sid: subscription.sid,
+      globalSubscriptions: globalSubscriptionCount,
+      globalServers: globalServerCount
+    });
 
     var options = parseUrl(subscription.url);
 
@@ -361,8 +477,23 @@ DeviceClient.prototype.unsubscribeAll = function(serviceId) {
       if(res.statusCode !== 200) {
         var err = new Error('UNSUBSCRIBE error');
         err.statusCode = res.statusCode;
+        subscriptionLogger('ERROR', 'UNSUBSCRIBE_ALL failed - subscription may remain on host', {
+          device: deviceName,
+          service: serviceId,
+          sid: subscription.sid,
+          statusCode: res.statusCode
+        });
         return self.emit('error', err);
       }
+
+      globalSubscriptionCount = Math.max(0, globalSubscriptionCount - 1);
+      delete self._subscriptionCreatedAt[serviceId];
+      subscriptionLogger('INFO', 'UNSUBSCRIBE_ALL success', {
+        device: deviceName,
+        service: serviceId,
+        globalSubscriptions: globalSubscriptionCount,
+        globalServers: globalServerCount
+      });
 
       clearTimeout(self.subscriptions[serviceId].timer);
       delete self.subscriptions[serviceId];
@@ -372,8 +503,18 @@ DeviceClient.prototype.unsubscribeAll = function(serviceId) {
     });
 
     req.on('error', function(err) {
+      subscriptionLogger('WARN', 'UNSUBSCRIBE_ALL request error - cleaning up locally but subscription may remain on host', {
+        device: deviceName,
+        service: serviceId,
+        sid: subscription.sid,
+        error: err.message,
+        globalSubscriptions: globalSubscriptionCount,
+        globalServers: globalServerCount
+      });
       self.emit('error', err);
       // well this may occur if the client was removed and can not answer anymore, so we have to remove the subscription!
+      globalSubscriptionCount = Math.max(0, globalSubscriptionCount - 1);
+      delete self._subscriptionCreatedAt[serviceId];
       clearTimeout(self.subscriptions[serviceId].timer);
       delete self.subscriptions[serviceId];
       self.releaseEventingServer();
@@ -387,9 +528,16 @@ DeviceClient.prototype.unsubscribeAll = function(serviceId) {
 
 DeviceClient.prototype.ensureEventingServer = function(callback) {
   var self = this;
+  var deviceName = this.deviceDescription ? this.deviceDescription.friendlyName : this.url;
 
   if(!this.server) {
-    debug('create eventing server');
+    globalServerCount++;
+    subscriptionLogger('INFO', 'Creating eventing server', {
+      device: deviceName,
+      globalSubscriptions: globalSubscriptionCount,
+      globalServers: globalServerCount
+    });
+    
     this.server = http.createServer(function(req, res) {
 
       req.pipe(concat(function(buf) {
@@ -400,10 +548,13 @@ DeviceClient.prototype.ensureEventingServer = function(callback) {
           events = parseEvents(buf);
         }
         catch (ex) {
+          subscriptionLogger('ERROR', 'Failed to parse events', {
+            device: deviceName,
+            sid: sid,
+            error: ex.message
+          });
           return;
         }
-        //console.log(events);
-        //console.log('received events %s %d %j', sid, seq, events);
 
         debug('received events %s %d %j', sid, seq, events);
 
@@ -414,14 +565,19 @@ DeviceClient.prototype.ensureEventingServer = function(callback) {
 
         var idx = sids.indexOf(sid);
         if(idx === -1) {
-          debug('WARNING unknown SID %s', sid);
-          // silently ignore unknown SIDs
+          subscriptionLogger('WARN', 'Received event for UNKNOWN SID - possible orphaned subscription on host', {
+            device: deviceName,
+            unknownSid: sid,
+            knownSids: sids,
+            globalSubscriptions: globalSubscriptionCount
+          });
+          // Still respond with 200 to not cause issues on host
+          res.end();
           return;
         }
 
         var serviceId = keys[idx];
         var listeners = self.subscriptions[serviceId].listeners;
-        
         
 
         // Dispatch each event to each listener registered for
@@ -447,6 +603,13 @@ DeviceClient.prototype.ensureEventingServer = function(callback) {
   if(!this.listening) {
     this.server.on('listening', function() {
       self.listening = true;
+      var address = self.server.address();
+      subscriptionLogger('INFO', 'Eventing server listening', {
+        device: deviceName,
+        address: address.address,
+        port: address.port,
+        globalServers: globalServerCount
+      });
       callback();
     });
   } else {
@@ -456,14 +619,28 @@ DeviceClient.prototype.ensureEventingServer = function(callback) {
 
 
 DeviceClient.prototype.releaseEventingServer = function(_force = false) {
-  if(Object.keys(this.subscriptions).length === 0 || _force) {
-    debug('shutdown eventing server');
-    if(this.server)
-    {
+  var deviceName = this.deviceDescription ? this.deviceDescription.friendlyName : this.url;
+  var subscriptionCount = Object.keys(this.subscriptions).length;
+  
+  if(subscriptionCount === 0 || _force) {
+    if(this.server) {
+      globalServerCount = Math.max(0, globalServerCount - 1);
+      subscriptionLogger('INFO', 'Releasing eventing server', {
+        device: deviceName,
+        forced: _force,
+        remainingSubscriptions: subscriptionCount,
+        globalSubscriptions: globalSubscriptionCount,
+        globalServers: globalServerCount
+      });
       this.server.close();
       this.server = null;
       this.listening = false;
     }
+  } else {
+    subscriptionLogger('DEBUG', 'Not releasing eventing server - subscriptions still active', {
+      device: deviceName,
+      remainingSubscriptions: subscriptionCount
+    });
   }
 };
 
@@ -711,5 +888,9 @@ function resolveService(serviceId) {
     : serviceId;  
 }
 
+
+// Export additional utilities for monitoring
+DeviceClient.setSubscriptionLogger = setSubscriptionLogger;
+DeviceClient.getSubscriptionMetrics = getSubscriptionMetrics;
 
 module.exports = DeviceClient;

--- a/lib/lib.external.upnp-device-client.js
+++ b/lib/lib.external.upnp-device-client.js
@@ -46,7 +46,7 @@ function DeviceClient(url) {
   this.subscriptions = {};
   this.userAgent = "";
   this._subscriptionCreatedAt = {}; // Track when subscriptions were created
-}
+  this.activeSockets = []; // FIX Phase 2b: Track active sockets for cleanup
 
 util.inherits(DeviceClient, EventEmitter);
 
@@ -629,6 +629,19 @@ DeviceClient.prototype.ensureEventingServer = function(callback) {
     // be sure that we are listening on the correct interface where the client resides
     var iface = this.getIfaceForUrl(this.url);
     this.server.listen(0, ip.address(iface));
+    
+    // FIX Phase 2b: Track active sockets to force cleanup on release
+    // Node.js server.close() does not close idle Keep-Alive connections, 
+    // leading to socket leaks on the host. We must track and destroy them manually.
+    this.server.on('connection', function(socket) {
+      self.activeSockets.push(socket);
+      socket.on('close', function() {
+        var idx = self.activeSockets.indexOf(socket);
+        if (idx !== -1) {
+          self.activeSockets.splice(idx, 1);
+        }
+      });
+    });
   }
 
   if(!this.listening) {
@@ -661,8 +674,19 @@ DeviceClient.prototype.releaseEventingServer = function(_force = false) {
         forced: _force,
         remainingSubscriptions: subscriptionCount,
         globalSubscriptions: globalSubscriptionCount,
-        globalServers: globalServerCount
+        globalServers: globalServerCount,
+        activeSockets: this.activeSockets.length
       });
+      
+      // FIX Phase 2b: Force destroy all active sockets
+      // This is required because server.close() only stops accepting NEW connections
+      // but keeps existing Keep-Alive connections open indefinitely.
+      if (this.activeSockets) {
+        this.activeSockets.forEach(function(socket) {
+          socket.destroy();
+        });
+      }
+      
       this.server.close();
       this.server = null;
       this.listening = false;

--- a/lib/lib.external.upnp-device-client.js
+++ b/lib/lib.external.upnp-device-client.js
@@ -288,16 +288,31 @@ DeviceClient.prototype.subscribe = function(serviceId, listener) {
             if(res.statusCode !== 200) {
               var err = new Error('SUBSCRIBE renewal error');
               err.statusCode = res.statusCode;
-              subscriptionLogger('ERROR', 'SUBSCRIBE renewal failed - POTENTIAL LEAK', {
+              subscriptionLogger('ERROR', 'SUBSCRIBE renewal failed - cleaning up to prevent leak', {
                 device: deviceName,
                 service: serviceId,
                 sid: sid,
                 statusCode: res.statusCode,
                 globalSubscriptions: globalSubscriptionCount,
-                globalServers: globalServerCount,
-                note: 'Old subscription may remain on host'
+                globalServers: globalServerCount
               });
-              // XXX: should we clear the subscription and release the server here ?
+              
+              // FIX: Clean up the failed subscription to prevent connection leak
+              if(self.subscriptions[serviceId]) {
+                clearTimeout(self.subscriptions[serviceId].timer);
+                delete self.subscriptions[serviceId];
+              }
+              delete self._subscriptionCreatedAt[serviceId];
+              globalSubscriptionCount = Math.max(0, globalSubscriptionCount - 1);
+              self.releaseEventingServer();
+              
+              subscriptionLogger('INFO', 'Cleaned up failed subscription', {
+                device: deviceName,
+                service: serviceId,
+                globalSubscriptions: globalSubscriptionCount,
+                globalServers: globalServerCount
+              });
+              
               self.emit('error', err);
               return;
             }
@@ -317,15 +332,31 @@ DeviceClient.prototype.subscribe = function(serviceId, listener) {
           });
 
           req.on('error', function(err) {
-            subscriptionLogger('ERROR', 'SUBSCRIBE renewal request error - POTENTIAL LEAK', {
+            subscriptionLogger('ERROR', 'SUBSCRIBE renewal network error - cleaning up to prevent leak', {
               device: deviceName,
               service: serviceId,
               sid: sid,
               error: err.message,
               globalSubscriptions: globalSubscriptionCount,
-              globalServers: globalServerCount,
-              note: 'Old subscription may remain on host'
+              globalServers: globalServerCount
             });
+            
+            // FIX: Clean up the failed subscription to prevent connection leak
+            if(self.subscriptions[serviceId]) {
+              clearTimeout(self.subscriptions[serviceId].timer);
+              delete self.subscriptions[serviceId];
+            }
+            delete self._subscriptionCreatedAt[serviceId];
+            globalSubscriptionCount = Math.max(0, globalSubscriptionCount - 1);
+            self.releaseEventingServer();
+            
+            subscriptionLogger('INFO', 'Cleaned up failed subscription after network error', {
+              device: deviceName,
+              service: serviceId,
+              globalSubscriptions: globalSubscriptionCount,
+              globalServers: globalServerCount
+            });
+            
             self.emit('error', err);
           });
 

--- a/lib/lib.external.upnp-device-client.js
+++ b/lib/lib.external.upnp-device-client.js
@@ -47,6 +47,7 @@ function DeviceClient(url) {
   this.userAgent = "";
   this._subscriptionCreatedAt = {}; // Track when subscriptions were created
   this.activeSockets = []; // FIX Phase 2b: Track active sockets for cleanup
+}
 
 util.inherits(DeviceClient, EventEmitter);
 

--- a/lib/lib.external.upnp-device-client.js
+++ b/lib/lib.external.upnp-device-client.js
@@ -17,11 +17,16 @@ var SUBSCRIPTION_TIMEOUT = 300;
 var globalSubscriptionCount = 0;
 var globalServerCount = 0;
 
-// Logging function that can be overridden for integration with external loggers
+// Logging function - only WARN and ERROR go to console by default
+// DEBUG and INFO use the debug() mechanism (enable with DEBUG=upnp-device-client)
 var subscriptionLogger = function(level, message, context) {
-  var timestamp = new Date().toISOString();
   var contextStr = context ? ' ' + JSON.stringify(context) : '';
-  console.log('[' + timestamp + '] [UPnP-Client] [' + level + '] ' + message + contextStr);
+  if (level === 'ERROR' || level === 'WARN') {
+    console.log('[UPnP-Client] [' + level + '] ' + message + contextStr);
+  } else {
+    // DEBUG and INFO use the debug package (silent unless DEBUG env var is set)
+    debug('[' + level + '] ' + message + contextStr);
+  }
 };
 
 function setSubscriptionLogger(logger) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "node": ">=7.6.0"
   },
   "name": "node-raumkernel",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "description": "Library to control the raumfeld multiroom system",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When subscription renewal fails (either with HTTP error or network error), we now clean up the subscription locally to prevent orphaned subscriptions from accumulating.

This happens when a device switches from Spotify Connect mode to regular playback. 

Changes:
- On renewal status code != 200: clean up timer, delete subscription, decrement global counter
- On renewal network error: same cleanup logic
- Added logging for successful cleanup operations
- Bump version to 1.2.24

This fixes the connection leak where ~1000+ connections would accumulate on the Raumfeld host over 2 days of operation, eventually causing it to become unresponsive.