### PR TITLE
fix: add Connection: close header to SUBSCRIBE/UNSUBSCRIBE requests

### DIFF
--- a/lib/lib.external.upnp-device-client.js
+++ b/lib/lib.external.upnp-device-client.js
@@ -239,7 +239,8 @@ DeviceClient.prototype.subscribe = function(serviceId, listener) {
         'USER-AGENT': [self.userAgent, OS_VERSION, 'UPnP/1.1', PACKAGE_VERSION].join(' '),
         'CALLBACK': '<http://' + server.address().address + ':' + server.address().port + '/>',
         'NT': 'upnp:event',
-        'TIMEOUT': 'Second-' + SUBSCRIPTION_TIMEOUT
+        'TIMEOUT': 'Second-' + SUBSCRIPTION_TIMEOUT,
+        'Connection': 'close'
       };
 
       var req = http.request(options, function(res) {
@@ -287,7 +288,8 @@ DeviceClient.prototype.subscribe = function(serviceId, listener) {
           options.headers = {
             'HOST': options.host,
             'SID': sid,
-            'TIMEOUT': 'Second-' + SUBSCRIPTION_TIMEOUT
+            'TIMEOUT': 'Second-' + SUBSCRIPTION_TIMEOUT,
+            'Connection': 'close'
           };
 
           var req = http.request(options, function(res) {
@@ -425,7 +427,8 @@ DeviceClient.prototype.unsubscribe = function(serviceId, listener) {
     options.method = 'UNSUBSCRIBE';
     options.headers = {
       'HOST': options.host,
-      'SID': subscription.sid
+      'SID': subscription.sid,
+      'Connection': 'close'
     };
 
     var req = http.request(options, function(res) {
@@ -507,7 +510,8 @@ DeviceClient.prototype.unsubscribeAll = function(serviceId) {
     options.method = 'UNSUBSCRIBE';
     options.headers = {
       'HOST': options.host,
-      'SID': subscription.sid
+      'SID': subscription.sid,
+      'Connection': 'close'
     };
 
     var req = http.request(options, function(res) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "node": ">=7.6.0"
   },
   "name": "node-raumkernel",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "description": "Library to control the raumfeld multiroom system",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Prevents HTTP Keep-Alive connection leak on Raumfeld host by explicitly closing connections after SUBSCRIBE (initial and renewal) and UNSUBSCRIBE requests.

Without this header, Node.js defaults to HTTP/1.1 Keep-Alive, causing connections to accumulate on the host (observed 300+ connections).

Bumps version to 1.2.25.