### PR TITLE
fix: prevent TypeError race condition during UPnP unsubscription

### DIFF
--- a/lib/lib.external.upnp-device-client.js
+++ b/lib/lib.external.upnp-device-client.js
@@ -453,8 +453,10 @@ DeviceClient.prototype.unsubscribe = function(serviceId, listener) {
         globalServers: globalServerCount
       });
 
-      clearTimeout(self.subscriptions[serviceId].timer);
-      delete self.subscriptions[serviceId];
+      if (self.subscriptions[serviceId]) {
+        clearTimeout(self.subscriptions[serviceId].timer);
+        delete self.subscriptions[serviceId];
+      }
       // Make sure the eventing server is shutdown if there is no
       // subscription left for any service
       self.releaseEventingServer();
@@ -473,8 +475,10 @@ DeviceClient.prototype.unsubscribe = function(serviceId, listener) {
       // well this may occur if the client was removed and can not answer anymore, so we have to remove the subscription!
       globalSubscriptionCount = Math.max(0, globalSubscriptionCount - 1);
       delete self._subscriptionCreatedAt[serviceId];
-      clearTimeout(self.subscriptions[serviceId].timer);
-      delete self.subscriptions[serviceId];
+      if (self.subscriptions[serviceId]) {
+        clearTimeout(self.subscriptions[serviceId].timer);
+        delete self.subscriptions[serviceId];
+      }
       self.releaseEventingServer();
     });
 
@@ -536,8 +540,10 @@ DeviceClient.prototype.unsubscribeAll = function(serviceId) {
         globalServers: globalServerCount
       });
 
-      clearTimeout(self.subscriptions[serviceId].timer);
-      delete self.subscriptions[serviceId];
+      if (self.subscriptions[serviceId]) {
+        clearTimeout(self.subscriptions[serviceId].timer);
+        delete self.subscriptions[serviceId];
+      }
       // Make sure the eventing server is shutdown if there is no
       // subscription left for any service
       self.releaseEventingServer();
@@ -556,8 +562,10 @@ DeviceClient.prototype.unsubscribeAll = function(serviceId) {
       // well this may occur if the client was removed and can not answer anymore, so we have to remove the subscription!
       globalSubscriptionCount = Math.max(0, globalSubscriptionCount - 1);
       delete self._subscriptionCreatedAt[serviceId];
-      clearTimeout(self.subscriptions[serviceId].timer);
-      delete self.subscriptions[serviceId];
+      if (self.subscriptions[serviceId]) {
+        clearTimeout(self.subscriptions[serviceId].timer);
+        delete self.subscriptions[serviceId];
+      }
       self.releaseEventingServer();
     });
 


### PR DESCRIPTION
AI Disclaimer: Detecting the issue was conducted with help of AI, review has been done by human :) 


## About 
Fixes a race condition in `lib.external.upnp-device-client.js` that causes the Node.js process to crash with the following error:

```
TypeError: Cannot read properties of undefined (reading 'timer') at ClientRequest. (/app/node_modules/node-raumkernel/lib/lib.external.upnp-device-client.js:559:50)
``` 

Example Bug report e.g. in https://github.com/ulilicht/ha-raumkernel/issues/63 

## Background 
My understanding is this can happen when the network connection to a device is lost. The fix should be safe - only "if exists" check added. 


## AI Analysis 
When a Raumfeld device goes offline or the network drops, two things can happen simultaneously:
1. A background `renew()` timer fires, fails with a network error, and deletes the local `self.subscriptions[serviceId]` object.
2. The system realizes the device is gone and triggers `unsubscribeAll()`. The resulting HTTP `UNSUBSCRIBE` request also fails (e.g., `ETIMEDOUT`).

When the `unsubscribeAll` error callback fires, it blindly tried to call `clearTimeout(self.subscriptions[serviceId].timer)`. Since the object was already deleted by the `renew` failure, this threw a fatal `TypeError`.

